### PR TITLE
Reverse child hash order

### DIFF
--- a/circuits/imt/utils.go
+++ b/circuits/imt/utils.go
@@ -14,7 +14,7 @@ func assertDifferentIfEnabled(api frontend.API, a, b, enabled frontend.Variable)
 }
 
 func hashSwitcher(api frontend.API, indexBit, hash, sibling frontend.Variable) frontend.Variable {
-	l := api.Select(indexBit, hash, sibling)
-	r := api.Select(indexBit, sibling, hash)
+	l := api.Select(indexBit, sibling, hash)
+	r := api.Select(indexBit, hash, sibling)
 	return api.Select(api.IsZero(sibling), hash, poseidon.Hash(api, []frontend.Variable{l, r}))
 }

--- a/imt/proof.go
+++ b/imt/proof.go
@@ -48,9 +48,9 @@ func (p *proof) Valid(t TreeReader) (bool, error) {
 		level--
 		if p.siblings[level].Cmp(big.NewInt(0)) != 0 {
 			if index%2 == 0 {
-				h, err = t.Hash([]*big.Int{p.siblings[level], h})
-			} else {
 				h, err = t.Hash([]*big.Int{h, p.siblings[level]})
+			} else {
+				h, err = t.Hash([]*big.Int{p.siblings[level], h})
 			}
 			if err != nil {
 				return false, err

--- a/imt/tree_writer.go
+++ b/imt/tree_writer.go
@@ -195,9 +195,9 @@ func (t *treeWriter) setNode(n *node) ([]*big.Int, error) {
 		siblings[level] = new(big.Int).SetBytes(siblingHashBytes)
 		if err == nil {
 			if index%2 == 0 {
-				h, err = t.hash([]*big.Int{siblings[level], h})
-			} else {
 				h, err = t.hash([]*big.Int{h, siblings[level]})
+			} else {
+				h, err = t.hash([]*big.Int{siblings[level], h})
 			}
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
Reverse the order of the binary node hashing to be more intuitive.

Note: this is a breaking change to existing users of the IMT.